### PR TITLE
change name mangling

### DIFF
--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/ViperPoweredDeclarationChecker.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.formver.reporting.reportVerifierError
 import org.jetbrains.kotlin.formver.viper.Verifier
 import org.jetbrains.kotlin.formver.viper.mangled
 import org.jetbrains.kotlin.formver.viper.ast.Program
+import org.jetbrains.kotlin.formver.viper.ast.registerAllNames
 import org.jetbrains.kotlin.formver.viper.ast.unwrapOr
 import org.jetbrains.kotlin.formver.viper.errors.VerifierError
 import org.jetbrains.kotlin.name.ClassId
@@ -49,7 +50,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             val programConversionContext = ProgramConverter(session, config, errorCollector)
             programConversionContext.registerForVerification(declaration)
             val program = programConversionContext.program
-
+            program.registerAllNames()
             getProgramForLogging(program)?.let {
                 reporter.reportOn(declaration.source, PluginErrors.VIPER_TEXT, declaration.name.asString(), it.toDebugOutput())
             }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/MangledName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/MangledName.kt
@@ -12,6 +12,12 @@ package org.jetbrains.kotlin.formver.viper
  * approach makes it easier to see where they came from during debugging.
  */
 interface MangledName {
+    companion object {
+        val registeredNames = mutableSetOf<String>()
+        fun register(name: MangledName) {
+            registeredNames.add(name.mangled)
+        }
+    }
     val mangledType: String?
         get() = null
     val mangledScope: String?
@@ -20,4 +26,12 @@ interface MangledName {
 }
 
 val MangledName.mangled: String
-    get() = listOfNotNull(mangledType, mangledScope, mangledBaseName).joinToString("$")
+    //get() = listOfNotNull(mangledType, mangledScope, mangledBaseName).joinToString("$")
+    get() {
+        var result = (mangledType?.plus("_") ?: "") + mangledBaseName
+        if (result in MangledName.registeredNames) {
+            result = (mangledScope?.plus("_") ?: "") + result
+        }
+
+        return result
+    }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -48,3 +48,11 @@ data class Program(
 
     fun toDebugOutput(): String = toSilver().toString()
 }
+fun Program.registerAllNames() {
+    val prog = this
+    domains.forEach    { MangledName.register( it.name) }
+    fields.forEach     { MangledName.register( it.name) }
+    functions.forEach  { MangledName.register( it.name) }
+    predicates.forEach { MangledName.register( it.name) }
+    methods.forEach    { MangledName.register( it.name) }
+}


### PR DESCRIPTION
Added a companion object to MangledName for registering used names. In ViperPoweredDeclarationChecker, implemented registration of all program names after creation using the extension function Program.registerAllNames()