### PR TITLE
Implement context updates on function call

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -407,6 +407,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("partial_move.kt")
+    public void testPartial_move() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.kt");
+    }
+
+    @Test
     @TestMetadata("shared_to_shared.kt")
     public void testShared_to_shared() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/shared_to_shared.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -389,6 +389,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("consume_fields.kt")
+    public void testConsume_fields() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.kt");
+    }
+
+    @Test
     @TestMetadata("direct_pass_shared_to_unique.kt")
     public void testDirect_pass_shared_to_unique() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -417,6 +417,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     public void testShared_to_shared() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/shared_to_shared.kt");
     }
+
+    @Test
+    @TestMetadata("twice.kt")
+    public void testTwice() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/twice.kt");
+    }
   }
 
   @Nested

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.fir.diag.txt
@@ -1,0 +1,11 @@
+/consume_fields.kt:(477,552): error: attempting to access a non-accessible argument in z.y.x
+... while checking uniqueness level for fun consumeParent(@Unique z: B) {
+    consumeA(z.y)
+    consumeInt(z.y.x)
+}
+
+/consume_fields.kt:(554,636): error: uniqueness level not match z.y, required: Unique, actual: Shared
+... while checking uniqueness level for fun uniqueBecomeShared(@Unique z: B) {
+    makeIntoShared(z.y)
+    consumeA(z.y)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.fir.diag.txt
@@ -1,10 +1,16 @@
-/consume_fields.kt:(477,552): error: attempting to access a non-accessible argument in z.y.x
+/consume_fields.kt:(487,554): error: attempting to access a non-accessible argument a in consumeA(a)
+... while checking uniqueness level for fun doubleConsume(@Unique a: A) {
+    consumeA(a)
+    consumeA(a)
+}
+
+/consume_fields.kt:(556,631): error: attempting to access a non-accessible argument z.y.x in consumeInt(z.y.x)
 ... while checking uniqueness level for fun consumeParent(@Unique z: B) {
     consumeA(z.y)
     consumeInt(z.y.x)
 }
 
-/consume_fields.kt:(554,636): error: uniqueness level not match z.y, required: Unique, actual: Shared
+/consume_fields.kt:(633,715): error: uniqueness level not match z.y, required: Unique, actual: Shared
 ... while checking uniqueness level for fun uniqueBecomeShared(@Unique z: B) {
     makeIntoShared(z.y)
     consumeA(z.y)

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.kt
@@ -1,0 +1,35 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+import org.jetbrains.kotlin.formver.plugin.NeverVerify
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class A {
+    @Unique val x = 1
+}
+
+class B {
+    @Unique val y = A()
+}
+
+fun consumeInt(@Unique a: Int) {}
+fun consumeA(@Unique a: A) {}
+fun consumeB(@Unique a: B) {}
+
+fun makeIntoShared(a: A) {}
+
+fun valid_consume_all(@Unique z: B) {
+    consumeInt(z.y.x)
+    consumeA(z.y)
+    consumeB(z)
+}
+
+<!UNIQUENESS_VIOLATION!>fun consumeParent(@Unique z: B) {
+    consumeA(z.y)
+    consumeInt(z.y.x)
+}<!>
+
+<!UNIQUENESS_VIOLATION!>fun uniqueBecomeShared(@Unique z: B) {
+    makeIntoShared(z.y)
+    consumeA(z.y)
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_fields.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
     @Unique val x = 1
+    @Unique val w = 2
 }
 
 class B {
@@ -20,9 +21,13 @@ fun makeIntoShared(a: A) {}
 
 fun valid_consume_all(@Unique z: B) {
     consumeInt(z.y.x)
-    consumeA(z.y)
-    consumeB(z)
+    consumeInt(z.y.w)
 }
+
+<!UNIQUENESS_VIOLATION!>fun doubleConsume(@Unique a: A) {
+    consumeA(a)
+    consumeA(a)
+}<!>
 
 <!UNIQUENESS_VIOLATION!>fun consumeParent(@Unique z: B) {
     consumeA(z.y)
@@ -33,3 +38,8 @@ fun valid_consume_all(@Unique z: B) {
     makeIntoShared(z.y)
     consumeA(z.y)
 }<!>
+
+fun uniqueBecomeSharedValid(@Unique z: B) {
+    makeIntoShared(z.y)
+    makeIntoShared(z.y)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.fir.diag.txt
@@ -1,4 +1,4 @@
-/direct_pass_shared_to_unique.kt:(212,242): error: uniqueness level not match y
+/direct_pass_shared_to_unique.kt:(212,242): error: uniqueness level not match y, required: Unique, actual: Shared
 ... while checking uniqueness level for fun use_f(y: Int) {
     f(y)
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.fir.diag.txt
@@ -1,4 +1,4 @@
-/multi_level.kt:(361,401): error: uniqueness level not match z.y.x
+/multi_level.kt:(361,401): error: uniqueness level not match z.y.x, required: Unique, actual: Shared
 ... while checking uniqueness level for fun use_g(@Unique z: B) {
     g(z.y.x)
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.fir.diag.txt
@@ -1,0 +1,5 @@
+/partial_move.kt:(286,344): error: attempting to pass a partially moved argument a in takesA(a)
+... while checking uniqueness level for fun test(@Unique a: A) {
+    dropB(a.data)
+    takesA(a)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.kt
@@ -1,0 +1,20 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+import org.jetbrains.kotlin.formver.plugin.NeverVerify
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class B
+
+class A(
+    @Unique val data: B,
+)
+
+fun takesA(@Unique a: A) {}
+fun dropB(@Unique b: B) {}
+
+<!UNIQUENESS_VIOLATION!>fun test(@Unique a: A) {
+    dropB(a.data)
+    takesA(a)
+}<!>
+

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/twice.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/twice.kt
@@ -1,0 +1,21 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.NeverConvert
+import org.jetbrains.kotlin.formver.plugin.NeverVerify
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class A {
+    @Unique val x = 1
+}
+
+fun consumeInt(@Unique x: Int) {}
+
+fun moveTwice(@Unique x: Int, @Unique y: Int) {
+    consumeInt(x)
+    consumeInt(y)
+}
+
+fun moveMemberTwice(@Unique x: A, @Unique y: A) {
+    consumeInt(x.x)
+    consumeInt(y.x)
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueChecker.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.formver.common.ErrorCollector
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.name.ClassId
@@ -24,10 +25,23 @@ class UniqueChecker(
     private val uniqueId: ClassId
         get() = getAnnotationId("Unique")
 
+    private val uniquenessContext: MutableMap<FirBasedSymbol<*>, UniqueLevel> = mutableMapOf()
+
     override fun resolveUniqueAnnotation(declaration: HasAnnotation): UniqueLevel {
         if (declaration.hasAnnotation(uniqueId, session)) {
             return UniqueLevel.Unique
         }
         return UniqueLevel.Shared
+    }
+
+    override fun getUniqueLevel(symbol: FirBasedSymbol<*>): UniqueLevel {
+        val level = uniquenessContext.getOrPut(symbol) {
+            resolveUniqueAnnotation(symbol)
+        }
+        return level
+    }
+
+    override fun assignUniqueLevel(symbol: FirBasedSymbol<*>, level: UniqueLevel) {
+        uniquenessContext[symbol] = level
     }
 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
@@ -25,12 +25,27 @@ sealed interface HasAnnotation {
     fun hasAnnotation(id: ClassId, session: FirSession): Boolean
 }
 
+class UniqueLevelEmbedding(
+    private val uniqueContext: UniqueCheckerContext,
+    private val symbol: FirBasedSymbol<*>,
+) {
+    var level: UniqueLevel
+        get() = uniqueContext.getUniqueLevel(symbol)
+        set(newLevel) = uniqueContext.assignUniqueLevel(symbol, newLevel)
+}
+
 interface UniqueCheckerContext {
     val config: PluginConfiguration
     val errorCollector: ErrorCollector
     val session: FirSession
 
     fun resolveUniqueAnnotation(declaration: HasAnnotation): UniqueLevel
+
+    fun getUniqueLevel(symbol: FirBasedSymbol<*>): UniqueLevel
+    fun assignUniqueLevel(symbol: FirBasedSymbol<*>, level: UniqueLevel)
+
+    fun uniqueLevelOf(symbol: FirBasedSymbol<*>): UniqueLevelEmbedding =
+        UniqueLevelEmbedding(this, symbol)
 }
 
 fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirBasedSymbol<*>): UniqueLevel =

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
@@ -27,12 +27,14 @@ sealed interface HasAnnotation {
 
 class UniqueLevelEmbedding(
     private val uniqueContext: UniqueCheckerContext,
-    private val symbol: FirBasedSymbol<*>,
+    private val path: LocalPath
 ) {
     var level: UniqueLevel
-        get() = uniqueContext.getUniqueLevel(symbol)
-        set(newLevel) = uniqueContext.assignUniqueLevel(symbol, newLevel)
+        get() = uniqueContext.getUniqueLevel(path)
+        set(newLevel) = uniqueContext.assignUniqueLevel(path, newLevel)
 }
+
+data class LocalPath(val local: FirBasedSymbol<*>, val callee: FirBasedSymbol<*>)
 
 interface UniqueCheckerContext {
     val config: PluginConfiguration
@@ -41,11 +43,11 @@ interface UniqueCheckerContext {
 
     fun resolveUniqueAnnotation(declaration: HasAnnotation): UniqueLevel
 
-    fun getUniqueLevel(symbol: FirBasedSymbol<*>): UniqueLevel
-    fun assignUniqueLevel(symbol: FirBasedSymbol<*>, level: UniqueLevel)
+    fun getUniqueLevel(symbol: LocalPath): UniqueLevel
+    fun assignUniqueLevel(symbol: LocalPath, level: UniqueLevel)
 
-    fun markPartiallyMoved(symbol: FirBasedSymbol<*>, mark: Boolean = true)
-    fun isPartiallyMoved(symbol: FirBasedSymbol<*>): Boolean
+    fun markPartiallyMoved(symbol: LocalPath, mark: Boolean = true)
+    fun isPartiallyMoved(symbol: LocalPath): Boolean
 }
 
 fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirBasedSymbol<*>): UniqueLevel =
@@ -54,5 +56,5 @@ fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirBasedSymbol<*>)
 fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirAnnotationContainer): UniqueLevel =
     resolveUniqueAnnotation(HasAnnotation.AnnotationContainer(declaration))
 
-fun UniqueCheckerContext.uniqueLevelOf(symbol: FirBasedSymbol<*>): UniqueLevelEmbedding =
-    UniqueLevelEmbedding(this, symbol)
+fun UniqueCheckerContext.uniqueLevelOf(path: LocalPath): UniqueLevelEmbedding =
+    UniqueLevelEmbedding(this, path)

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckerContext.kt
@@ -44,8 +44,8 @@ interface UniqueCheckerContext {
     fun getUniqueLevel(symbol: FirBasedSymbol<*>): UniqueLevel
     fun assignUniqueLevel(symbol: FirBasedSymbol<*>, level: UniqueLevel)
 
-    fun uniqueLevelOf(symbol: FirBasedSymbol<*>): UniqueLevelEmbedding =
-        UniqueLevelEmbedding(this, symbol)
+    fun markPartiallyMoved(symbol: FirBasedSymbol<*>, mark: Boolean = true)
+    fun isPartiallyMoved(symbol: FirBasedSymbol<*>): Boolean
 }
 
 fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirBasedSymbol<*>): UniqueLevel =
@@ -53,3 +53,6 @@ fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirBasedSymbol<*>)
 
 fun UniqueCheckerContext.resolveUniqueAnnotation(declaration: FirAnnotationContainer): UniqueLevel =
     resolveUniqueAnnotation(HasAnnotation.AnnotationContainer(declaration))
+
+fun UniqueCheckerContext.uniqueLevelOf(symbol: FirBasedSymbol<*>): UniqueLevelEmbedding =
+    UniqueLevelEmbedding(this, symbol)


### PR DESCRIPTION
~~TODO: We need to pass along the context when calling the function so consumed paths aren't available inside of the called function as well~~