### PR TITLE
Simplify internal error handling.

### DIFF
--- a/formver.common/src/org/jetbrains/kotlin/formver/common/ErrorCollector.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/ErrorCollector.kt
@@ -7,12 +7,13 @@ package org.jetbrains.kotlin.formver.common
 
 import org.jetbrains.kotlin.KtSourceElement
 
-/** Collector for *internal* plugin errors.
+/** Collector for some plugin errors.
+ *
+ * We currently are not consistent with what we report this way, vs through other channels.
  *
  * TODO: Replace this with some kind of more systematic approach to generating diagnostics.
  */
 class ErrorCollector {
-    private val internalErrorInfos = mutableListOf<String>()
     private val minorErrors = mutableListOf<String>()
     private val purityErrors = mutableListOf<Pair<KtSourceElement, String>>()
 
@@ -22,13 +23,6 @@ class ErrorCollector {
 
     fun forEachMinorError(action: (String) -> Unit) {
         minorErrors.forEach(action)
-    }
-
-    fun formatErrorWithInfos(error: String): String =
-        internalErrorInfos.joinToString(prefix = "$error\n", separator = "\n")
-
-    fun addErrorInfo(msg: String) {
-        internalErrorInfos.add(msg)
     }
 
     fun addPurityError(position: KtSourceElement, msg: String) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -567,13 +567,3 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
 }
 
-object StmtConversionVisitorExceptionWrapper : FirVisitor<ExpEmbedding, StmtConversionContext>() {
-    override fun visitElement(element: FirElement, data: StmtConversionContext): ExpEmbedding {
-        try {
-            return element.accept(StmtConversionVisitor, data)
-        } catch (e: Exception) {
-            data.errorCollector.addErrorInfo("... while converting ${element.source.text}")
-            throw e
-        }
-    }
-}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConverter.kt
@@ -34,7 +34,7 @@ data class StmtConverter(
     override val activeCatchLabels: List<LabelEmbedding> = listOf(),
 ) : StmtConversionContext, MethodConversionContext by methodCtx {
     override fun convert(stmt: FirStatement): ExpEmbedding =
-        stmt.accept(StmtConversionVisitorExceptionWrapper, this).withPosition(stmt.source)
+        stmt.accept(StmtConversionVisitor, this).withPosition(stmt.source)
 
     override fun <R> withNewScope(action: StmtConversionContext.() -> R): R = withNewScopeImpl { action() }
     override fun <R> withNoScope(action: StmtConversionContext.() -> R): R =

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniqueDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniqueDeclarationChecker.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.formver.common.ErrorCollector
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.uniqueness.UniqueCheckVisitor
 import org.jetbrains.kotlin.formver.uniqueness.UniqueChecker
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessCheckException
 
 class UniqueDeclarationChecker(private val session: FirSession, private val config: PluginConfiguration) :
     FirSimpleFunctionChecker(MppCheckerKind.Common) {
@@ -27,9 +28,13 @@ class UniqueDeclarationChecker(private val session: FirSession, private val conf
         try {
             val uniqueCheckerContext = UniqueChecker(session, config, errorCollector)
             declaration.accept(UniqueCheckVisitor, uniqueCheckerContext)
-        } catch (e: Exception) {
+        }
+        catch (e: UniquenessCheckException) {
+            reporter.reportOn(e.source, PluginErrors.UNIQUENESS_VIOLATION, e.message)
+        }
+        catch (e: Exception) {
             val error = e.message ?: "No message provided"
-            reporter.reportOn(declaration.source, PluginErrors.UNIQUENESS_VIOLATION, error)
+            reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error)
         }
     }
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniqueDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniqueDeclarationChecker.kt
@@ -14,8 +14,8 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionC
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.formver.common.ErrorCollector
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
+import org.jetbrains.kotlin.formver.uniqueness.UniqueCheckVisitor
 import org.jetbrains.kotlin.formver.uniqueness.UniqueChecker
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessCheckExceptionWrapper
 
 class UniqueDeclarationChecker(private val session: FirSession, private val config: PluginConfiguration) :
     FirSimpleFunctionChecker(MppCheckerKind.Common) {
@@ -26,9 +26,9 @@ class UniqueDeclarationChecker(private val session: FirSession, private val conf
         val errorCollector = ErrorCollector()
         try {
             val uniqueCheckerContext = UniqueChecker(session, config, errorCollector)
-            declaration.accept(UniquenessCheckExceptionWrapper, uniqueCheckerContext)
+            declaration.accept(UniqueCheckVisitor, uniqueCheckerContext)
         } catch (e: Exception) {
-            val error = errorCollector.formatErrorWithInfos(e.message ?: "No message provided")
+            val error = e.message ?: "No message provided"
             reporter.reportOn(declaration.source, PluginErrors.UNIQUENESS_VIOLATION, error)
         }
     }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -90,7 +90,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
 
             verifier.verify(program, onFailure)
         } catch (e: Exception) {
-            val error = errorCollector.formatErrorWithInfos(e.message ?: "No message provided")
+            val error = e.message ?: "No message provided"
             reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error)
         }
 

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrowing.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrowing.fir.diag.txt
@@ -1,9 +1,3 @@
-/borrowing.kt:(635,704): error: attempting to pass argument z in consumeB(z) with incompatible borrowing level
-... while checking uniqueness level for fun borrowedToNonBorrowed(@Borrowed @Unique z: B) {
-    consumeB(z)
-}
+/borrowing.kt:(700,701): error: cannot pass borrowed value as non-borrowed
 
-/borrowing.kt:(706,787): error: attempting to pass argument y in makeIntoShared(y) with incompatible borrowing level
-... while checking uniqueness level for fun borrowedToNonBorrowedShared(@Borrowed @Unique y: A) {
-    makeIntoShared(y)
-}
+/borrowing.kt:(783,784): error: cannot pass borrowed value as non-borrowed

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrowing.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrowing.kt
@@ -31,10 +31,10 @@ fun valid_borrow(@Unique z: B) {
     consumeB(z)
 }
 
-<!UNIQUENESS_VIOLATION!>fun borrowedToNonBorrowed(@Borrowed @Unique z: B) {
-    consumeB(z)
-}<!>
+fun borrowedToNonBorrowed(@Borrowed @Unique z: B) {
+    consumeB(<!UNIQUENESS_VIOLATION!>z<!>)
+}
 
-<!UNIQUENESS_VIOLATION!>fun borrowedToNonBorrowedShared(@Borrowed @Unique y: A) {
-    makeIntoShared(y)
-}<!>
+fun borrowedToNonBorrowedShared(@Borrowed @Unique y: A) {
+    makeIntoShared(<!UNIQUENESS_VIOLATION!>y<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_properties.fir.diag.txt
@@ -1,17 +1,5 @@
-/consume_properties.kt:(487,554): error: attempting to access a non-accessible argument a in consumeA(a)
-... while checking uniqueness level for fun doubleConsume(@Unique a: A) {
-    consumeA(a)
-    consumeA(a)
-}
+/consume_properties.kt:(550,551): error: cannot access expression as its uniqueness state is top
 
-/consume_properties.kt:(556,631): error: attempting to access a non-accessible argument z.y.x in consumeInt(z.y.x)
-... while checking uniqueness level for fun consumeParent(@Unique z: B) {
-    consumeA(z.y)
-    consumeInt(z.y.x)
-}
+/consume_properties.kt:(623,628): error: cannot access expression as its uniqueness state is top
 
-/consume_properties.kt:(633,715): error: uniqueness level not match z.y, required: Unique, actual: Shared
-... while checking uniqueness level for fun uniqueBecomeShared(@Unique z: B) {
-    makeIntoShared(z.y)
-    consumeA(z.y)
-}
+/consume_properties.kt:(709,712): error: expected unique value, got shared

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_properties.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_properties.kt
@@ -24,20 +24,20 @@ fun valid_consume_all(@Unique z: B) {
     consumeInt(z.y.w)
 }
 
-<!UNIQUENESS_VIOLATION!>fun doubleConsume(@Unique a: A) {
+fun doubleConsume(@Unique a: A) {
     consumeA(a)
-    consumeA(a)
-}<!>
+    consumeA(<!UNIQUENESS_VIOLATION!>a<!>)
+}
 
-<!UNIQUENESS_VIOLATION!>fun consumeParent(@Unique z: B) {
+fun consumeParent(@Unique z: B) {
     consumeA(z.y)
-    consumeInt(z.y.x)
-}<!>
+    consumeInt(<!UNIQUENESS_VIOLATION!>z.y.x<!>)
+}
 
-<!UNIQUENESS_VIOLATION!>fun uniqueBecomeShared(@Unique z: B) {
+fun uniqueBecomeShared(@Unique z: B) {
     makeIntoShared(z.y)
-    consumeA(z.y)
-}<!>
+    consumeA(<!UNIQUENESS_VIOLATION!>z.y<!>)
+}
 
 fun uniqueBecomeSharedValid(@Unique z: B) {
     makeIntoShared(z.y)

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.fir.diag.txt
@@ -1,4 +1,1 @@
-/direct_pass_shared_to_unique.kt:(212,242): error: uniqueness level not match y, required: Unique, actual: Shared
-... while checking uniqueness level for fun use_f(y: Int) {
-    f(y)
-}
+/direct_pass_shared_to_unique.kt:(238,239): error: expected unique value, got shared

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/direct_pass_shared_to_unique.kt
@@ -8,6 +8,6 @@ fun f(@Unique x: Int) {
 
 }
 
-<!UNIQUENESS_VIOLATION!>fun use_f(y: Int) {
-    f(y)
-}<!>
+fun use_f(y: Int) {
+    f(<!UNIQUENESS_VIOLATION!>y<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.fir.diag.txt
@@ -1,4 +1,1 @@
-/multi_level.kt:(361,401): error: uniqueness level not match z.y.x, required: Unique, actual: Shared
-... while checking uniqueness level for fun use_g(@Unique z: B) {
-    g(z.y.x)
-}
+/multi_level.kt:(393,398): error: expected unique value, got shared

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/multi_level.kt
@@ -26,6 +26,6 @@ fun g(@Unique x: Int) {
 
 }
 
-<!UNIQUENESS_VIOLATION!>fun use_g(@Unique z: B) {
-    g(z.y.x)
-}<!>
+fun use_g(@Unique z: B) {
+    g(<!UNIQUENESS_VIOLATION!>z.y.x<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.fir.diag.txt
@@ -1,5 +1,1 @@
-/partial_move.kt:(286,344): error: attempting to pass a partially moved argument a in takesA(a)
-... while checking uniqueness level for fun test(@Unique a: A) {
-    dropB(a.data)
-    takesA(a)
-}
+/partial_move.kt:(340,341): error: a partially moved object cannot be passed as an argument

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partial_move.kt
@@ -13,8 +13,8 @@ class A(
 fun takesA(@Unique a: A) {}
 fun dropB(@Unique b: B) {}
 
-<!UNIQUENESS_VIOLATION!>fun test(@Unique a: A) {
+fun test(@Unique a: A) {
     dropB(a.data)
-    takesA(a)
-}<!>
+    takesA(<!UNIQUENESS_VIOLATION!>a<!>)
+}
 

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partially_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partially_shared.fir.diag.txt
@@ -1,5 +1,1 @@
-/partially_shared.kt:(281,342): error: attempting to pass a partially shared argument a in consumeA(a)
-... while checking uniqueness level for fun test(@Unique a: A) {
-    shareB(a.data)
-    consumeA(a)
-}
+/partially_shared.kt:(338,339): error: cannot pass a partially shared argument

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partially_shared.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/partially_shared.kt
@@ -13,8 +13,8 @@ class A(
 fun consumeA(@Unique a: A) {}
 fun shareB(b: B) {}
 
-<!UNIQUENESS_VIOLATION!>fun test(@Unique a: A) {
+fun test(@Unique a: A) {
     shareB(a.data)
-    consumeA(a)
-}<!>
+    consumeA(<!UNIQUENESS_VIOLATION!>a<!>)
+}
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckVisitor.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckVisitor.kt
@@ -7,13 +7,7 @@ package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
-import org.jetbrains.kotlin.fir.expressions.FirBlock
-import org.jetbrains.kotlin.fir.expressions.FirExpression
-import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
-import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
-import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
-import org.jetbrains.kotlin.fir.expressions.arguments
-import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -156,13 +150,3 @@ object UniqueCheckVisitor : FirVisitor<Pair<UniqueLevel, UniquePathContext?>, Un
     }
 }
 
-object UniquenessCheckExceptionWrapper : FirVisitor<Pair<UniqueLevel, UniquePathContext?>, UniqueCheckerContext>() {
-    override fun visitElement(element: FirElement, data: UniqueCheckerContext): Pair<UniqueLevel, UniquePathContext?> {
-        try {
-            return element.accept(UniqueCheckVisitor, data)
-        } catch (e: Exception) {
-            data.errorCollector.addErrorInfo("... while checking uniqueness level for ${element.source.text}")
-            throw e
-        }
-    }
-}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckVisitor.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueCheckVisitor.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
-import org.jetbrains.kotlin.text
 
 object PathVisitor : FirVisitor<List<FirBasedSymbol<*>>, Unit>() {
     override fun visitElement(element: FirElement, data: Unit) =
@@ -85,27 +84,42 @@ object UniqueCheckVisitor : FirVisitor<Pair<UniqueLevel, UniquePathContext?>, Un
         val (requiredUnique, requiredBorrowing) = requirements
         val (argumentUnique, argumentBorrowing) = actual
 
-        require(argumentUnique != UniqueLevel.Top) {
-            "attempting to access a non-accessible argument ${argument.source.text} in ${functionCall.source.text}"
+        if (argumentUnique == UniqueLevel.Top) {
+            throw UniquenessCheckException(
+                argument.source,
+                "cannot access expression as its uniqueness state is top"
+            )
         }
 
         val argumentSubtreeLUB = pathContext?.subtreeLUB
-        require(argumentSubtreeLUB != UniqueLevel.Top) {
-            "attempting to pass a partially moved argument ${argument.source.text} in ${functionCall.source.text}"
+        if (argumentSubtreeLUB == UniqueLevel.Top) {
+            throw UniquenessCheckException(
+                argument.source,
+                "a partially moved object cannot be passed as an argument"
+            )
         }
 
-        require(argumentBorrowing <= requiredBorrowing) {
-            "attempting to pass argument ${argument.source.text} in ${functionCall.source.text} with incompatible borrowing level"
+        if (argumentBorrowing > requiredBorrowing) {
+            throw UniquenessCheckException(
+                argument.source,
+                "cannot pass borrowed value as non-borrowed"
+            )
         }
 
         if (requiredUnique == UniqueLevel.Unique) {
-            require(argumentUnique == UniqueLevel.Unique) {
-                "uniqueness level not match ${argument.source.text}, required: Unique, actual: $argumentUnique"
+            if (argumentUnique != UniqueLevel.Unique) {
+                throw UniquenessCheckException(
+                    argument.source,
+                    "expected unique value, got ${argumentUnique.toString().lowercase()}"
+                )
             }
 
             val subtreeChanged = with(data) { pathContext?.hasChanges ?: false }
-            require(!subtreeChanged) {
-                "attempting to pass a partially shared argument ${argument.source.text} in ${functionCall.source.text}"
+            if (subtreeChanged) {
+                throw UniquenessCheckException(
+                    argument.source,
+                    "cannot pass a partially shared argument"
+                )
             }
         }
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniqueChecker.kt
@@ -31,24 +31,15 @@ class UniqueChecker(
 
     private val uniqueContext = ContextTrie(null, null, mutableMapOf(), UniqueLevel.Unique)
 
-    override fun resolveUniqueAnnotation(declaration: HasAnnotation): UniqueLevel {
-        if (declaration.hasAnnotation(uniqueId, session)) {
-            return UniqueLevel.Unique
-        }
-        return UniqueLevel.Shared
-    }
+    override fun resolveUniqueAnnotation(declaration: HasAnnotation): UniqueLevel =
+        if (declaration.hasAnnotation(uniqueId, session)) UniqueLevel.Unique else UniqueLevel.Shared
 
-    override fun resolveBorrowingAnnotation(declaration: HasAnnotation): BorrowingLevel {
-        if (declaration.hasAnnotation(borrowingId, session)) {
-            return BorrowingLevel.Borrowed
-        }
-        return BorrowingLevel.Plain
-    }
+    override fun resolveBorrowingAnnotation(declaration: HasAnnotation): BorrowingLevel =
+        if (declaration.hasAnnotation(borrowingId, session)) BorrowingLevel.Borrowed else BorrowingLevel.Plain
 
     override fun getOrPutPath(path: List<FirBasedSymbol<*>>): UniquePathContext {
         require(path.isNotEmpty()) { "Provided path is empty" }
-        val head = path.first()
-        require(head is FirValueParameterSymbol) { "Provided path does not start with a local variable" }
+        require(path.first() is FirValueParameterSymbol) { "Provided path does not start with a local variable" }
 
         return uniqueContext.getOrPutPath(path)
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessCheckException.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessCheckException.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.kotlin.formver.uniqueness
+
+import org.jetbrains.kotlin.KtSourceElement
+
+class UniquenessCheckException(val source: KtSourceElement?, override val message: String) : Exception()


### PR DESCRIPTION
Remove the nested structure we used to get when traversing the tree.  If we want errors from a specific point, we should really just log the source position, not this kind of mess of collecting it separately.