### PR TITLE
Add registration phase

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
@@ -19,4 +19,5 @@ import org.jetbrains.kotlin.formver.viper.SEPARATOR
 class SimpleNameResolver : NameResolver {
     override fun resolve(name: MangledName): String =
         listOfNotNull(name.mangledType, name.mangledScope, name.mangledBaseName).joinToString(SEPARATOR)
+    override fun registry(name: MangledName) {}
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
@@ -19,5 +19,5 @@ import org.jetbrains.kotlin.formver.viper.SEPARATOR
 class SimpleNameResolver : NameResolver {
     override fun resolve(name: MangledName): String =
         listOfNotNull(name.mangledType, name.mangledScope, name.mangledBaseName).joinToString(SEPARATOR)
-    override fun registry(name: MangledName) {}
+    override fun register(name: MangledName) {}
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.plugin.compiler.reporting.reportVerifierError
 import org.jetbrains.kotlin.formver.viper.Verifier
 import org.jetbrains.kotlin.formver.viper.ast.Program
+import org.jetbrains.kotlin.formver.viper.ast.registerAllNames
 import org.jetbrains.kotlin.formver.viper.ast.unwrapOr
 import org.jetbrains.kotlin.formver.viper.errors.VerifierError
 import org.jetbrains.kotlin.formver.viper.mangled
@@ -54,6 +55,9 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             programConversionContext.registerForVerification(declaration)
             val program = programConversionContext.program
 
+            with(programConversionContext.nameResolver) {
+                program.registerAllNames()
+            }
             getProgramForLogging(program)?.let {
                 reporter.reportOn(
                     declaration.source,

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/NameResolver.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/NameResolver.kt
@@ -12,10 +12,10 @@ import org.jetbrains.kotlin.formver.viper.MangledName
 
 interface NameResolver {
     fun resolve(name: MangledName): String
-    fun registry(name: MangledName)
+    fun register(name: MangledName)
 }
 
 class DebugNameResolver : NameResolver {
     override fun resolve(name: MangledName): String = listOfNotNull(name.mangledType, name.mangledScope, name.mangledBaseName).joinToString(SEPARATOR)
-    override fun registry(name: MangledName) {}
+    override fun register(name: MangledName) {}
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/NameResolver.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/NameResolver.kt
@@ -12,8 +12,10 @@ import org.jetbrains.kotlin.formver.viper.MangledName
 
 interface NameResolver {
     fun resolve(name: MangledName): String
+    fun registry(name: MangledName)
 }
 
 class DebugNameResolver : NameResolver {
     override fun resolve(name: MangledName): String = listOfNotNull(name.mangledType, name.mangledScope, name.mangledBaseName).joinToString(SEPARATOR)
+    override fun registry(name: MangledName) {}
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -8,18 +8,22 @@ package org.jetbrains.kotlin.formver.viper.ast
 import org.jetbrains.kotlin.formver.viper.*
 import viper.silver.ast.*
 
+sealed interface BinaryExp : Exp {
+    val left: Exp
+    val right: Exp
+}
 sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
 
     val type: Type
 
     //region Arithmetic Expressions
     data class Add(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Add =
@@ -27,12 +31,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Sub(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Sub =
@@ -40,12 +44,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Mul(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Mul =
@@ -53,12 +57,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Div(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Div =
@@ -66,12 +70,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Mod(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Mod =
@@ -81,12 +85,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
 
     //region Integer Comparison Expressions
     data class LtCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LtCmp =
@@ -94,12 +98,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class LeCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LeCmp =
@@ -107,12 +111,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class GtCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.GtCmp =
@@ -120,12 +124,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class GeCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.GeCmp =
@@ -135,12 +139,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
 
     //region Boolean Comparison Expressions
     data class EqCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.EqCmp =
@@ -148,12 +152,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class NeCmp(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.NeCmp =
@@ -163,12 +167,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
 
     //region Boolean Expressions
     data class And(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.And =
@@ -176,12 +180,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Or(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Or =
@@ -189,12 +193,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class Implies(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Implies =
@@ -485,12 +489,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     }
 
     data class SeqAppend(
-        val left: Exp,
-        val right: Exp,
+        override val left: Exp,
+        override val right: Exp,
         val pos: Position = Position.NoPosition,
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
-    ) : Exp {
+    ) : BinaryExp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqAppend =
             viper.silver.ast.SeqAppend.apply(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -53,13 +53,13 @@ data class Program(
 context(nameResolver: NameResolver)
 private fun registerExpNames(exp: Exp) {
     when (exp) {
-        is Exp.LocalVar -> nameResolver.registry(exp.name)
+        is Exp.LocalVar -> nameResolver.register(exp.name)
         is Exp.FieldAccess -> {
-            nameResolver.registry(exp.field.name)
+            nameResolver.register(exp.field.name)
             registerExpNames(exp.rcv)
         }
         is Exp.PredicateAccess -> {
-            nameResolver.registry(exp.predicateName)
+            nameResolver.register(exp.predicateName)
             exp.formalArgs.forEach { registerExpNames(it) }
         }
         is BinaryExp -> {
@@ -67,12 +67,12 @@ private fun registerExpNames(exp: Exp) {
             registerExpNames(exp.right)
         }
         is Exp.FuncApp -> {
-            nameResolver.registry(exp.functionName)
+            nameResolver.register(exp.functionName)
             exp.args.forEach { registerExpNames(it) }
         }
         is Exp.DomainFuncApp -> {
-            nameResolver.registry(exp.function.name)
-            exp.function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+            nameResolver.register(exp.function.name)
+            exp.function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
             exp.args.forEach { registerExpNames(it) }
         }
         else -> { }
@@ -83,24 +83,24 @@ context(nameResolver: NameResolver)
 private fun Program.registerSeqnNames(seqn: Stmt.Seqn) {
     seqn.scopedSeqnDeclarations.forEach { decl ->
         when (decl) {
-            is Declaration.LocalVarDecl -> nameResolver.registry(decl.name)
-            is Declaration.LabelDecl -> nameResolver.registry(decl.name)
+            is Declaration.LocalVarDecl -> nameResolver.register(decl.name)
+            is Declaration.LabelDecl -> nameResolver.register(decl.name)
         }
     }
     seqn.stmts.forEach { stmt ->
         when (stmt) {
-            is Stmt.Label -> nameResolver.registry(stmt.name)
+            is Stmt.Label -> nameResolver.register(stmt.name)
             is Stmt.Seqn -> registerSeqnNames(stmt)
-            is Stmt.Goto -> nameResolver.registry(stmt.name)
-            is Stmt.MethodCall -> nameResolver.registry(stmt.methodName)
+            is Stmt.Goto -> nameResolver.register(stmt.name)
+            is Stmt.MethodCall -> nameResolver.register(stmt.methodName)
             is Stmt.If -> {
                 registerSeqnNames(stmt.then)
                 stmt.els?.let { registerSeqnNames(it) }
             }
             is Stmt.While -> registerSeqnNames(stmt.body)
-            is Stmt.LocalVarAssign -> nameResolver.registry(stmt.lhs.name)
-            is Stmt.Fold -> nameResolver.registry(stmt.acc.predicateName)
-            is Stmt.Unfold -> nameResolver.registry(stmt.acc.predicateName)
+            is Stmt.LocalVarAssign -> nameResolver.register(stmt.lhs.name)
+            is Stmt.Fold -> nameResolver.register(stmt.acc.predicateName)
+            is Stmt.Unfold -> nameResolver.register(stmt.acc.predicateName)
             else -> { }
         }
     }
@@ -109,30 +109,30 @@ private fun Program.registerSeqnNames(seqn: Stmt.Seqn) {
 context(nameResolver: NameResolver)
 fun Program.registerAllNames() {
     domains.forEach { domain ->
-        nameResolver.registry(domain.name)
+        nameResolver.register(domain.name)
         domain.functions.forEach { function ->
-            nameResolver.registry(function.name)
-            function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+            nameResolver.register(function.name)
+            function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
         }
     }
-    fields.forEach { nameResolver.registry(it.name) }
+    fields.forEach { nameResolver.register(it.name) }
 
     functions.forEach { function ->
-        nameResolver.registry(function.name)
-        function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        nameResolver.register(function.name)
+        function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
         function.body?.let { exp -> registerExpNames(exp) }
     }
 
     predicates.forEach { predicate ->
-        nameResolver.registry(predicate.name)
-        predicate.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        nameResolver.register(predicate.name)
+        predicate.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
         registerExpNames(predicate.body)
     }
 
     methods.forEach { method ->
-        nameResolver.registry(method.name)
-        method.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
-        method.formalReturns.forEach { ret -> nameResolver.registry(ret.name) }
+        nameResolver.register(method.name)
+        method.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
+        method.formalReturns.forEach { ret -> nameResolver.register(ret.name) }
         method.body?.let { seqn -> registerSeqnNames(seqn) }
     }
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -50,3 +50,89 @@ data class Program(
     context(nameResolver: NameResolver)
     fun toDebugOutput(): String = toSilver().toString()
 }
+context(nameResolver: NameResolver)
+private fun registerExpNames(exp: Exp) {
+    when (exp) {
+        is Exp.LocalVar -> nameResolver.registry(exp.name)
+        is Exp.FieldAccess -> {
+            nameResolver.registry(exp.field.name)
+            registerExpNames(exp.rcv)
+        }
+        is Exp.PredicateAccess -> {
+            nameResolver.registry(exp.predicateName)
+            exp.formalArgs.forEach { registerExpNames(it) }
+        }
+        is BinaryExp -> {
+            registerExpNames(exp.left)
+            registerExpNames(exp.right)
+        }
+        is Exp.FuncApp -> {
+            nameResolver.registry(exp.functionName)
+            exp.args.forEach { registerExpNames(it) }
+        }
+        is Exp.DomainFuncApp -> {
+            nameResolver.registry(exp.function.name)
+            exp.function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+            exp.args.forEach { registerExpNames(it) }
+        }
+        else -> { }
+    }
+}
+
+context(nameResolver: NameResolver)
+private fun Program.registerSeqnNames(seqn: Stmt.Seqn) {
+    seqn.scopedSeqnDeclarations.forEach { decl ->
+        when (decl) {
+            is Declaration.LocalVarDecl -> nameResolver.registry(decl.name)
+            is Declaration.LabelDecl -> nameResolver.registry(decl.name)
+        }
+    }
+    seqn.stmts.forEach { stmt ->
+        when (stmt) {
+            is Stmt.Label -> nameResolver.registry(stmt.name)
+            is Stmt.Seqn -> registerSeqnNames(stmt)
+            is Stmt.Goto -> nameResolver.registry(stmt.name)
+            is Stmt.MethodCall -> nameResolver.registry(stmt.methodName)
+            is Stmt.If -> {
+                registerSeqnNames(stmt.then)
+                stmt.els?.let { registerSeqnNames(it) }
+            }
+            is Stmt.While -> registerSeqnNames(stmt.body)
+            is Stmt.LocalVarAssign -> nameResolver.registry(stmt.lhs.name)
+            is Stmt.Fold -> nameResolver.registry(stmt.acc.predicateName)
+            is Stmt.Unfold -> nameResolver.registry(stmt.acc.predicateName)
+            else -> { }
+        }
+    }
+}
+
+context(nameResolver: NameResolver)
+fun Program.registerAllNames() {
+    domains.forEach { domain ->
+        nameResolver.registry(domain.name)
+        domain.functions.forEach { function ->
+            nameResolver.registry(function.name)
+            function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        }
+    }
+    fields.forEach { nameResolver.registry(it.name) }
+
+    functions.forEach { function ->
+        nameResolver.registry(function.name)
+        function.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        function.body?.let { exp -> registerExpNames(exp) }
+    }
+
+    predicates.forEach { predicate ->
+        nameResolver.registry(predicate.name)
+        predicate.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        registerExpNames(predicate.body)
+    }
+
+    methods.forEach { method ->
+        nameResolver.registry(method.name)
+        method.formalArgs.forEach { arg -> nameResolver.registry(arg.name) }
+        method.formalReturns.forEach { ret -> nameResolver.registry(ret.name) }
+        method.body?.let { seqn -> registerSeqnNames(seqn) }
+    }
+}


### PR DESCRIPTION
- Added `registry` method to `NameResolver` interface for name registration
- Introduced `BinaryExp` interface to unify binary expressions
- Implemented recursive name registration for all Viper AST elements via `registerAllNames`
- Added name registration phase in `ViperPoweredDeclarationChecker`
 